### PR TITLE
refactor: typed dataclasses for coordinator data

### DIFF
--- a/custom_components/klereo/__init__.py
+++ b/custom_components/klereo/__init__.py
@@ -12,7 +12,7 @@ from .coordinator import KlereoCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/klereo/api.py
+++ b/custom_components/klereo/api.py
@@ -32,6 +32,14 @@ OUT_MODE_REGUL = 3
 OUT_STATE_OFF = 0
 OUT_STATE_ON = 1
 
+# Human-readable output mode labels (int → label)
+OUTPUT_MODES = {
+    OUT_MODE_MAN: "Manual",
+    OUT_MODE_TIME_SLOTS: "Time Slots",
+    OUT_MODE_TIMER: "Timer",
+    OUT_MODE_REGUL: "Regulation",
+}
+
 
 class KlereoApiError(Exception):
     """Error from the Klereo API."""

--- a/custom_components/klereo/coordinator.py
+++ b/custom_components/klereo/coordinator.py
@@ -11,11 +11,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .api import KlereoApi, KlereoApiError
 from .const import SCAN_INTERVAL_MINUTES
+from .models import KlereoPoolDetails, KlereoSystemData, KlereoSystemInfo
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class KlereoCoordinator(DataUpdateCoordinator):
+class KlereoCoordinator(DataUpdateCoordinator[dict[str, KlereoSystemData]]):
     """Klereo data update coordinator."""
 
     api: KlereoApi
@@ -30,7 +31,7 @@ class KlereoCoordinator(DataUpdateCoordinator):
         )
         self.api = api
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> dict[str, KlereoSystemData]:
         """Fetch data from the Klereo API."""
         try:
             systems_response = await self.api.get_systems()
@@ -49,8 +50,8 @@ class KlereoCoordinator(DataUpdateCoordinator):
                 system_list = []
 
             # Build system map
-            data: dict = {}
-            system_map: dict = {}
+            data: dict[str, KlereoSystemData] = {}
+            system_map: dict[str, dict] = {}
             for system in system_list:
                 sys_id = system.get("idSystem")
                 if sys_id:
@@ -64,7 +65,7 @@ class KlereoCoordinator(DataUpdateCoordinator):
 
             for sys_id, result in zip(system_map, details_results):
                 system = system_map[sys_id]
-                details = system.copy()
+                details_raw = system.copy()
 
                 if isinstance(result, Exception):
                     _LOGGER.warning(
@@ -74,15 +75,12 @@ class KlereoCoordinator(DataUpdateCoordinator):
                 elif isinstance(result, dict):
                     response_data = result.get("response")
                     if isinstance(response_data, list) and response_data:
-                        details.update(response_data[0])
+                        details_raw.update(response_data[0])
 
-                # Build index dicts for O(1) entity lookup
-                probes = details.get("probes", [])
-                outs = details.get("outs", [])
-                details["_probe_index"] = {p["index"]: p for p in probes if "index" in p}
-                details["_output_index"] = {o["index"]: o for o in outs if "index" in o}
-
-                data[sys_id] = {"info": system, "details": details}
+                data[sys_id] = KlereoSystemData(
+                    info=KlereoSystemInfo.from_dict(system),
+                    details=KlereoPoolDetails.from_dict(details_raw),
+                )
 
             return data
 

--- a/custom_components/klereo/diagnostics.py
+++ b/custom_components/klereo/diagnostics.py
@@ -1,4 +1,6 @@
 """Diagnostics support for Klereo."""
+from dataclasses import asdict
+
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD
@@ -14,7 +16,11 @@ async def async_get_config_entry_diagnostics(
 ) -> dict:
     """Return diagnostics for a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator_data = {
+        sys_id: asdict(system_data)
+        for sys_id, system_data in coordinator.data.items()
+    }
     return {
         "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),
-        "coordinator_data": async_redact_data(coordinator.data, TO_REDACT),
+        "coordinator_data": async_redact_data(coordinator_data, TO_REDACT),
     }

--- a/custom_components/klereo/entity.py
+++ b/custom_components/klereo/entity.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import KlereoCoordinator
+from .models import KlereoPoolDetails
 
 
 class KlereoEntity(CoordinatorEntity[KlereoCoordinator]):
@@ -24,8 +25,8 @@ class KlereoEntity(CoordinatorEntity[KlereoCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
-        system = self.coordinator.data.get(self.system_id, {})
-        name = system.get("info", {}).get("poolNickname", "Klereo Pool")
+        system = self.coordinator.data.get(self.system_id)
+        name = system.info.pool_nickname if system else "Klereo Pool"
         return DeviceInfo(
             identifiers={(DOMAIN, self.system_id)},
             name=name,
@@ -38,7 +39,7 @@ def setup_discovery(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
-    extract_fn: Callable[[KlereoCoordinator, str, dict], list[KlereoEntity]],
+    extract_fn: Callable[[KlereoCoordinator, str, KlereoPoolDetails], list[KlereoEntity]],
 ) -> None:
     """Set up dynamic entity discovery for a platform.
 
@@ -53,8 +54,7 @@ def setup_discovery(
     def _discover() -> None:
         new_entities: list[KlereoEntity] = []
         for system_id, system_data in coordinator.data.items():
-            details = system_data.get("details", {})
-            for uid, entity in extract_fn(coordinator, system_id, details):
+            for uid, entity in extract_fn(coordinator, system_id, system_data.details):
                 if uid not in known_ids:
                     known_ids.add(uid)
                     new_entities.append(entity)

--- a/custom_components/klereo/models.py
+++ b/custom_components/klereo/models.py
@@ -1,0 +1,107 @@
+"""Typed data models for Klereo."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class KlereoProbe:
+    """A Klereo probe sensor reading."""
+
+    index: int
+    type: int | None = None
+    status: int | None = None
+    value: float | None = None
+    filtered_value: float | None = None
+    direct_value: float | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KlereoProbe:
+        """Parse a probe dict from the API."""
+        return cls(
+            index=data["index"],
+            type=data.get("type"),
+            status=data.get("status"),
+            value=data.get("value"),
+            filtered_value=data.get("filteredValue"),
+            direct_value=data.get("directValue"),
+        )
+
+
+@dataclass
+class KlereoOutput:
+    """A Klereo controllable output."""
+
+    index: int
+    status: int = 0
+    mode: int = 0
+    type: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KlereoOutput:
+        """Parse an output dict from the API."""
+        return cls(
+            index=data["index"],
+            status=data.get("status", 0),
+            mode=data.get("mode", 0),
+            type=data.get("type", 0),
+        )
+
+
+@dataclass
+class KlereoSystemInfo:
+    """Metadata for a Klereo pool system."""
+
+    id_system: str
+    pool_nickname: str = "Klereo Pool"
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KlereoSystemInfo:
+        """Parse a system info dict from the API."""
+        return cls(
+            id_system=data.get("idSystem", ""),
+            pool_nickname=data.get("poolNickname", "Klereo Pool"),
+            raw=data,
+        )
+
+
+@dataclass
+class KlereoPoolDetails:
+    """Parsed pool details for a single system."""
+
+    probes: list[KlereoProbe] = field(default_factory=list)
+    outs: list[KlereoOutput] = field(default_factory=list)
+    regul_modes: dict[str, Any] = field(default_factory=dict)
+    probe_index: dict[int, KlereoProbe] = field(default_factory=dict)
+    output_index: dict[int, KlereoOutput] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> KlereoPoolDetails:
+        """Parse pool details from the API."""
+        probes = [
+            KlereoProbe.from_dict(p)
+            for p in data.get("probes", [])
+            if p.get("index") is not None
+        ]
+        outs = [
+            KlereoOutput.from_dict(o)
+            for o in data.get("outs", [])
+            if o.get("index") is not None
+        ]
+        return cls(
+            probes=probes,
+            outs=outs,
+            regul_modes=dict(data.get("RegulModes", {})),
+            probe_index={p.index: p for p in probes},
+            output_index={o.index: o for o in outs},
+        )
+
+
+@dataclass
+class KlereoSystemData:
+    """Combined info + details for a single pool system."""
+
+    info: KlereoSystemInfo
+    details: KlereoPoolDetails

--- a/custom_components/klereo/number.py
+++ b/custom_components/klereo/number.py
@@ -8,14 +8,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import PARAM_TYPES
 from .entity import KlereoEntity, setup_discovery
+from .models import KlereoPoolDetails
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _extract_numbers(coordinator, system_id, details):
+def _extract_numbers(coordinator, system_id, details: KlereoPoolDetails):
     """Extract number entities from system details."""
     items = []
-    for key, value in details.get("RegulModes", {}).items():
+    for key, value in details.regul_modes.items():
         if key not in PARAM_TYPES:
             continue
         uid = f"{system_id}_number_{key}"
@@ -54,12 +55,12 @@ class KlereoNumber(KlereoEntity, NumberEntity):
     @callback
     def _handle_coordinator_update(self):
         """Handle updated data from the coordinator."""
-        if self.system_id not in self.coordinator.data:
+        system = self.coordinator.data.get(self.system_id)
+        if system is None:
             self._attr_available = False
             return super()._handle_coordinator_update()
         self._attr_available = True
-        details = self.coordinator.data[self.system_id].get("details", {})
-        regul = details.get("RegulModes", {})
+        regul = system.details.regul_modes
         if self._key in regul:
             self._attr_native_value = regul[self._key]
         super()._handle_coordinator_update()

--- a/custom_components/klereo/select.py
+++ b/custom_components/klereo/select.py
@@ -1,0 +1,99 @@
+"""Select platform for Klereo."""
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .api import OUTPUT_MODES
+from .const import OUTPUT_NAMES
+from .entity import KlereoEntity, setup_discovery
+from .models import KlereoOutput, KlereoPoolDetails
+
+_LOGGER = logging.getLogger(__name__)
+
+# Reverse lookup: label → mode int
+_MODE_BY_LABEL = {v: k for k, v in OUTPUT_MODES.items()}
+
+
+def _extract_selects(coordinator, system_id, details: KlereoPoolDetails):
+    """Extract output mode selects from system details."""
+    items = []
+    for output in details.outs:
+        uid = f"{system_id}_output_mode_{output.index}"
+        items.append((uid, KlereoOutputModeSelect(coordinator, system_id, output)))
+    return items
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Klereo output mode selects."""
+    setup_discovery(hass, entry, async_add_entities, _extract_selects)
+
+
+class KlereoOutputModeSelect(KlereoEntity, SelectEntity):
+    """Representation of a Klereo output mode selector."""
+
+    _attr_options = list(OUTPUT_MODES.values())
+
+    def __init__(self, coordinator, system_id, output: KlereoOutput):
+        """Initialize the select entity."""
+        super().__init__(coordinator, system_id)
+        self._output_index = output.index
+
+        self._attr_unique_id = f"{system_id}_output_mode_{self._output_index}"
+        self._attr_name = f"{OUTPUT_NAMES.get(self._output_index, f'Output {self._output_index}')} Mode"
+
+        self._update_from_output(output)
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Handle updated data from the coordinator."""
+        output = self._find_my_output()
+        if output:
+            self._attr_available = True
+            self._update_from_output(output)
+        else:
+            self._attr_available = False
+        super()._handle_coordinator_update()
+
+    def _update_from_output(self, output: KlereoOutput):
+        """Update state from output data."""
+        mode = output.mode
+        if mode is not None:
+            try:
+                self._attr_current_option = OUTPUT_MODES.get(int(mode), OUTPUT_MODES[0])
+            except (ValueError, TypeError):
+                _LOGGER.warning("Unexpected mode value %r for output %s", mode, self._output_index)
+                self._attr_current_option = OUTPUT_MODES[0]
+        else:
+            self._attr_current_option = OUTPUT_MODES[0]
+
+    def _find_my_output(self) -> KlereoOutput | None:
+        """Find this output's data in the coordinator data."""
+        system = self.coordinator.data.get(self.system_id)
+        if system is None:
+            return None
+        return system.details.output_index.get(self._output_index)
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the output mode."""
+        mode = _MODE_BY_LABEL[option]
+        # Read current state so we preserve ON/OFF
+        output = self._find_my_output()
+        current_state = 0
+        if output:
+            try:
+                current_state = int(output.status)
+            except (ValueError, TypeError):
+                current_state = 0
+
+        self._attr_current_option = option
+        self.async_write_ha_state()
+        await self.coordinator.async_set_output(
+            self.system_id, self._output_index, mode, current_state
+        )

--- a/custom_components/klereo/sensor.py
+++ b/custom_components/klereo/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import PARAM_NAMES, PARAM_TYPES, SENSOR_TYPES
 from .entity import KlereoEntity, setup_discovery
+from .models import KlereoPoolDetails, KlereoProbe
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,16 +19,14 @@ def _humanize_key(key: str) -> str:
     return re.sub(r"(?<=[a-z])(?=[A-Z])", " ", key)
 
 
-def _extract_sensors(coordinator, system_id, details):
+def _extract_sensors(coordinator, system_id, details: KlereoPoolDetails):
     """Extract probe sensors and param sensors from system details."""
     items = []
-    for probe in details.get("probes", []):
-        if probe.get("index") is None:
-            continue
-        uid = f"{system_id}_sensor_{probe['index']}"
+    for probe in details.probes:
+        uid = f"{system_id}_sensor_{probe.index}"
         items.append((uid, KlereoSensor(coordinator, system_id, probe)))
 
-    for key, value in details.get("RegulModes", {}).items():
+    for key, value in details.regul_modes.items():
         if key in PARAM_TYPES:
             continue
         uid = f"{system_id}_param_{key}"
@@ -47,11 +46,11 @@ async def async_setup_entry(
 class KlereoSensor(KlereoEntity, SensorEntity):
     """Representation of a Klereo probe sensor."""
 
-    def __init__(self, coordinator, system_id, sensor_data):
+    def __init__(self, coordinator, system_id, probe: KlereoProbe):
         """Initialize the sensor."""
         super().__init__(coordinator, system_id)
-        self._index = sensor_data.get("index")
-        self._type = sensor_data.get("type")
+        self._index = probe.index
+        self._type = probe.type
 
         sensor_def = SENSOR_TYPES.get(self._type, {})
 
@@ -64,36 +63,36 @@ class KlereoSensor(KlereoEntity, SensorEntity):
         if state_class:
             self._attr_state_class = SensorStateClass(state_class)
 
-        self._update_from_data(sensor_data)
+        self._update_from_probe(probe)
 
     @callback
     def _handle_coordinator_update(self):
         """Handle updated data from the coordinator."""
-        data = self._find_my_data()
-        if data:
+        probe = self._find_my_probe()
+        if probe:
             self._attr_available = True
-            self._update_from_data(data)
+            self._update_from_probe(probe)
         else:
             self._attr_available = False
         super()._handle_coordinator_update()
 
-    def _update_from_data(self, data):
+    def _update_from_probe(self, probe: KlereoProbe):
         """Update state from probe data."""
-        value = data.get("filteredValue")
+        value = probe.filtered_value
         if value is None:
-            value = data.get("directValue")
+            value = probe.direct_value
         self._attr_native_value = value
         self._attr_extra_state_attributes = {
-            "type": data.get("type"),
-            "status": data.get("status"),
+            "type": probe.type,
+            "status": probe.status,
         }
 
-    def _find_my_data(self):
+    def _find_my_probe(self) -> KlereoProbe | None:
         """Find this probe's data in the coordinator data."""
-        if self.system_id not in self.coordinator.data:
+        system = self.coordinator.data.get(self.system_id)
+        if system is None:
             return None
-        details = self.coordinator.data[self.system_id].get("details", {})
-        return details.get("_probe_index", {}).get(self._index)
+        return system.details.probe_index.get(self._index)
 
 
 class KlereoParamSensor(KlereoEntity, SensorEntity):
@@ -111,12 +110,12 @@ class KlereoParamSensor(KlereoEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self):
         """Handle updated data from the coordinator."""
-        if self.system_id not in self.coordinator.data:
+        system = self.coordinator.data.get(self.system_id)
+        if system is None:
             self._attr_available = False
             return super()._handle_coordinator_update()
         self._attr_available = True
-        details = self.coordinator.data[self.system_id].get("details", {})
-        regul = details.get("RegulModes", {})
+        regul = system.details.regul_modes
         if self._key in regul:
             self._attr_native_value = regul[self._key]
         super()._handle_coordinator_update()

--- a/custom_components/klereo/switch.py
+++ b/custom_components/klereo/switch.py
@@ -9,17 +9,16 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .api import OUT_MODE_MAN, OUT_STATE_OFF, OUT_STATE_ON
 from .const import OUTPUT_NAMES
 from .entity import KlereoEntity, setup_discovery
+from .models import KlereoOutput, KlereoPoolDetails
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _extract_switches(coordinator, system_id, details):
+def _extract_switches(coordinator, system_id, details: KlereoPoolDetails):
     """Extract output switches from system details."""
     items = []
-    for output in details.get("outs", []):
-        if output.get("index") is None:
-            continue
-        uid = f"{system_id}_output_{output['index']}"
+    for output in details.outs:
+        uid = f"{system_id}_output_{output.index}"
         items.append((uid, KlereoSwitch(coordinator, system_id, output)))
     return items
 
@@ -36,32 +35,32 @@ async def async_setup_entry(
 class KlereoSwitch(KlereoEntity, SwitchEntity):
     """Representation of a Klereo output switch."""
 
-    def __init__(self, coordinator, system_id, output_data):
+    def __init__(self, coordinator, system_id, output: KlereoOutput):
         """Initialize the switch."""
         super().__init__(coordinator, system_id)
-        self._output_index = output_data.get("index")
+        self._output_index = output.index
 
         self._attr_unique_id = f"{system_id}_output_{self._output_index}"
         self._attr_name = OUTPUT_NAMES.get(
             self._output_index, f"Output {self._output_index}"
         )
 
-        self._update_from_data(output_data)
+        self._update_from_output(output)
 
     @callback
     def _handle_coordinator_update(self):
         """Handle updated data from the coordinator."""
-        data = self._find_my_data()
-        if data:
+        output = self._find_my_output()
+        if output:
             self._attr_available = True
-            self._update_from_data(data)
+            self._update_from_output(output)
         else:
             self._attr_available = False
         super()._handle_coordinator_update()
 
-    def _update_from_data(self, data):
+    def _update_from_output(self, output: KlereoOutput):
         """Update state from output data."""
-        status = data.get("status")
+        status = output.status
         if status is not None:
             try:
                 self._attr_is_on = int(status) == OUT_STATE_ON
@@ -71,16 +70,16 @@ class KlereoSwitch(KlereoEntity, SwitchEntity):
         else:
             self._attr_is_on = False
         self._attr_extra_state_attributes = {
-            "mode": data.get("mode"),
-            "type": data.get("type"),
+            "mode": output.mode,
+            "type": output.type,
         }
 
-    def _find_my_data(self):
+    def _find_my_output(self) -> KlereoOutput | None:
         """Find this output's data in the coordinator data."""
-        if self.system_id not in self.coordinator.data:
+        system = self.coordinator.data.get(self.system_id)
+        if system is None:
             return None
-        details = self.coordinator.data[self.system_id].get("details", {})
-        return details.get("_output_index", {}).get(self._output_index)
+        return system.details.output_index.get(self._output_index)
 
     async def async_turn_on(self, **kwargs):
         """Turn the output on (Manual mode, ON state)."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -5,6 +5,7 @@ import pytest
 
 from custom_components.klereo.api import KlereoApi
 from custom_components.klereo.coordinator import KlereoCoordinator
+from custom_components.klereo.models import KlereoSystemData
 
 
 @pytest.fixture
@@ -51,7 +52,8 @@ class TestAsyncUpdateData:
         }
         result = await coordinator._async_update_data()
         assert "SYS1" in result
-        assert result["SYS1"]["info"]["idSystem"] == "SYS1"
+        assert isinstance(result["SYS1"], KlereoSystemData)
+        assert result["SYS1"].info.id_system == "SYS1"
 
     async def test_parses_list_format(self, coordinator, mock_api):
         """Should parse direct list format."""
@@ -61,6 +63,7 @@ class TestAsyncUpdateData:
         mock_api.get_pool_details.return_value = {"response": [{}]}
         result = await coordinator._async_update_data()
         assert "SYS1" in result
+        assert isinstance(result["SYS1"], KlereoSystemData)
 
     async def test_parses_list_systems_format(self, coordinator, mock_api):
         """Should parse {list_systems: [...]} format."""
@@ -72,7 +75,7 @@ class TestAsyncUpdateData:
         assert "SYS1" in result
 
     async def test_builds_probe_index(self, coordinator, mock_api):
-        """Should build _probe_index for O(1) lookup."""
+        """Should build probe_index for O(1) lookup."""
         mock_api.get_systems.return_value = {
             "response": [{"idSystem": "SYS1"}]
         }
@@ -83,13 +86,13 @@ class TestAsyncUpdateData:
             ], "outs": []}]
         }
         result = await coordinator._async_update_data()
-        probe_idx = result["SYS1"]["details"]["_probe_index"]
+        probe_idx = result["SYS1"].details.probe_index
         assert 0 in probe_idx
         assert 1 in probe_idx
-        assert probe_idx[0]["filteredValue"] == 28.5
+        assert probe_idx[0].filtered_value == 28.5
 
     async def test_builds_output_index(self, coordinator, mock_api):
-        """Should build _output_index for O(1) lookup."""
+        """Should build output_index for O(1) lookup."""
         mock_api.get_systems.return_value = {
             "response": [{"idSystem": "SYS1"}]
         }
@@ -99,9 +102,9 @@ class TestAsyncUpdateData:
             ]}]
         }
         result = await coordinator._async_update_data()
-        out_idx = result["SYS1"]["details"]["_output_index"]
+        out_idx = result["SYS1"].details.output_index
         assert 0 in out_idx
-        assert out_idx[0]["status"] == 1
+        assert out_idx[0].status == 1
 
     async def test_skips_system_without_id(self, coordinator, mock_api):
         """Should skip systems without idSystem."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -5,6 +5,11 @@ from custom_components.klereo.diagnostics import (
     TO_REDACT,
     async_get_config_entry_diagnostics,
 )
+from custom_components.klereo.models import (
+    KlereoPoolDetails,
+    KlereoSystemData,
+    KlereoSystemInfo,
+)
 
 
 class TestDiagnostics:
@@ -20,10 +25,10 @@ class TestDiagnostics:
         }
         coordinator = MagicMock()
         coordinator.data = {
-            "SYS1": {
-                "info": {"idSystem": "SYS1", "poolNickname": "My Pool"},
-                "details": {"probes": []},
-            }
+            "SYS1": KlereoSystemData(
+                info=KlereoSystemInfo(id_system="SYS1", pool_nickname="My Pool"),
+                details=KlereoPoolDetails(),
+            )
         }
         hass.data = {"klereo": {entry.entry_id: coordinator}}
 
@@ -40,7 +45,7 @@ class TestDiagnostics:
             "options": {},
         }
         coordinator = MagicMock()
-        coordinator.data = {"token": "should_be_redacted"}
+        coordinator.data = {}
         hass.data = {"klereo": {entry.entry_id: coordinator}}
 
         result = await async_get_config_entry_diagnostics(hass, entry)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,6 +3,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.klereo.models import (
+    KlereoPoolDetails,
+    KlereoSystemData,
+    KlereoSystemInfo,
+)
 from custom_components.klereo.number import KlereoNumber
 
 
@@ -12,12 +17,16 @@ def mock_coordinator():
     coordinator = MagicMock()
     coordinator.async_set_param = AsyncMock()
     coordinator.data = {
-        "SYS1": {
-            "info": {"idSystem": "SYS1", "poolNickname": "My Pool"},
-            "details": {
-                "RegulModes": {"ConsigneEau": 28, "ModeFiltration": 1},
-            },
-        }
+        "SYS1": KlereoSystemData(
+            info=KlereoSystemInfo(id_system="SYS1", pool_nickname="My Pool"),
+            details=KlereoPoolDetails(
+                probes=[],
+                outs=[],
+                regul_modes={"ConsigneEau": 28, "ModeFiltration": 1},
+                probe_index={},
+                output_index={},
+            ),
+        )
     }
     return coordinator
 
@@ -53,7 +62,7 @@ class TestKlereoNumber:
         """Should update value from coordinator data."""
         number = KlereoNumber(mock_coordinator, "SYS1", "ConsigneEau", 28)
         number.async_write_ha_state = MagicMock()
-        mock_coordinator.data["SYS1"]["details"]["RegulModes"]["ConsigneEau"] = 35
+        mock_coordinator.data["SYS1"].details.regul_modes["ConsigneEau"] = 35
         number._handle_coordinator_update()
         assert number._attr_native_value == 35
         assert number._attr_available is True

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,152 @@
+"""Tests for Klereo select entities."""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.klereo.api import (
+    OUT_MODE_TIME_SLOTS,
+    OUT_MODE_TIMER,
+    OUT_STATE_ON,
+)
+from custom_components.klereo.models import (
+    KlereoOutput,
+    KlereoPoolDetails,
+    KlereoSystemData,
+    KlereoSystemInfo,
+)
+from custom_components.klereo.select import KlereoOutputModeSelect
+
+
+def _make_output(**kwargs) -> KlereoOutput:
+    """Create a KlereoOutput with defaults."""
+    defaults = {"index": 0, "status": 1, "mode": 0, "type": 0}
+    defaults.update(kwargs)
+    return KlereoOutput(**defaults)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Create a mock coordinator."""
+    output = _make_output()
+    coordinator = MagicMock()
+    coordinator.async_set_output = AsyncMock()
+    coordinator.data = {
+        "SYS1": KlereoSystemData(
+            info=KlereoSystemInfo(id_system="SYS1", pool_nickname="My Pool"),
+            details=KlereoPoolDetails(
+                probes=[],
+                outs=[output],
+                regul_modes={},
+                probe_index={},
+                output_index={0: output},
+            ),
+        )
+    }
+    return coordinator
+
+
+class TestKlereoOutputModeSelect:
+    """Tests for KlereoOutputModeSelect."""
+
+    def test_creates_with_known_index(self, mock_coordinator):
+        """Should use OUTPUT_NAMES for known indices with ' Mode' suffix."""
+        output = _make_output()
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_name == "Lighting Mode"
+        assert select._attr_unique_id == "SYS1_output_mode_0"
+
+    def test_creates_with_unknown_index(self, mock_coordinator):
+        """Should fall back to 'Output N Mode' for unknown indices."""
+        output = _make_output(index=99)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_name == "Output 99 Mode"
+
+    def test_options_list(self, mock_coordinator):
+        """Should expose all four mode options."""
+        output = _make_output()
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_options == ["Manual", "Time Slots", "Timer", "Regulation"]
+
+    def test_current_option_manual(self, mock_coordinator):
+        """Should read 'Manual' from mode=0."""
+        output = _make_output(mode=0)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_current_option == "Manual"
+
+    def test_current_option_timer(self, mock_coordinator):
+        """Should read 'Timer' from mode=2."""
+        output = _make_output(mode=2)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_current_option == "Timer"
+
+    def test_current_option_string_mode(self, mock_coordinator):
+        """Should handle string mode values from API."""
+        output = _make_output(mode="3")
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_current_option == "Regulation"
+
+    def test_current_option_none_defaults_manual(self, mock_coordinator):
+        """Should default to Manual when mode is None."""
+        output = _make_output(mode=None)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        assert select._attr_current_option == "Manual"
+
+    async def test_select_option_preserves_state(self, mock_coordinator):
+        """Should send new mode with current ON/OFF state preserved."""
+        output = _make_output(status=1)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        select.async_write_ha_state = MagicMock()
+        await select.async_select_option("Timer")
+        mock_coordinator.async_set_output.assert_called_once_with(
+            "SYS1", 0, OUT_MODE_TIMER, OUT_STATE_ON
+        )
+        assert select._attr_current_option == "Timer"
+
+    async def test_select_option_off_state(self, mock_coordinator):
+        """Should preserve OFF state when changing mode."""
+        output = _make_output(status=0)
+        # Update the coordinator data to match
+        mock_coordinator.data["SYS1"].details.output_index[0] = output
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        select.async_write_ha_state = MagicMock()
+        await select.async_select_option("Time Slots")
+        mock_coordinator.async_set_output.assert_called_once_with(
+            "SYS1", 0, OUT_MODE_TIME_SLOTS, 0
+        )
+
+    def test_handle_coordinator_update_refreshes(self, mock_coordinator):
+        """Should update current option from coordinator data."""
+        output = _make_output(mode=0)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        select.async_write_ha_state = MagicMock()
+        # Update the output in coordinator data
+        mock_coordinator.data["SYS1"].details.output_index[0] = _make_output(mode=3)
+        select._handle_coordinator_update()
+        assert select._attr_current_option == "Regulation"
+        assert select._attr_available is True
+
+    def test_handle_coordinator_update_missing_system(self, mock_coordinator):
+        """Should mark unavailable when system disappears."""
+        output = _make_output()
+        select = KlereoOutputModeSelect(mock_coordinator, "MISSING", output)
+        select.async_write_ha_state = MagicMock()
+        select._handle_coordinator_update()
+        assert select._attr_available is False
+
+    def test_device_info(self, mock_coordinator):
+        """Should return device info from coordinator data."""
+        output = _make_output()
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        info = select.device_info
+        assert ("klereo", "SYS1") in info["identifiers"]
+        assert info["name"] == "My Pool"
+
+    async def test_select_option_error_propagates(self, mock_coordinator):
+        """Should propagate HomeAssistantError from coordinator."""
+        from homeassistant.exceptions import HomeAssistantError
+        mock_coordinator.async_set_output.side_effect = HomeAssistantError("Failed to set output 0: API down")
+        output = _make_output(status=1)
+        select = KlereoOutputModeSelect(mock_coordinator, "SYS1", output)
+        select.async_write_ha_state = MagicMock()
+        with pytest.raises(HomeAssistantError, match="Failed to set output"):
+            await select.async_select_option("Regulation")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,26 +3,38 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.klereo.models import (
+    KlereoPoolDetails,
+    KlereoProbe,
+    KlereoSystemData,
+    KlereoSystemInfo,
+)
 from custom_components.klereo.sensor import KlereoParamSensor, KlereoSensor
+
+
+def _make_probe(**kwargs) -> KlereoProbe:
+    """Create a KlereoProbe with defaults."""
+    defaults = {"index": 0, "type": 5, "filtered_value": 28.5, "direct_value": 28.4, "status": 0}
+    defaults.update(kwargs)
+    return KlereoProbe(**defaults)
 
 
 @pytest.fixture
 def mock_coordinator():
     """Create a mock coordinator."""
+    probe = _make_probe()
     coordinator = MagicMock()
     coordinator.data = {
-        "SYS1": {
-            "info": {"idSystem": "SYS1", "poolNickname": "My Pool"},
-            "details": {
-                "probes": [
-                    {"index": 0, "type": 5, "filteredValue": 28.5, "directValue": 28.4, "status": 0},
-                ],
-                "_probe_index": {
-                    0: {"index": 0, "type": 5, "filteredValue": 28.5, "directValue": 28.4, "status": 0},
-                },
-                "RegulModes": {"ConsigneEau": 28},
-            },
-        }
+        "SYS1": KlereoSystemData(
+            info=KlereoSystemInfo(id_system="SYS1", pool_nickname="My Pool"),
+            details=KlereoPoolDetails(
+                probes=[probe],
+                outs=[],
+                regul_modes={"ConsigneEau": 28},
+                probe_index={0: probe},
+                output_index={},
+            ),
+        )
     }
     return coordinator
 
@@ -32,7 +44,7 @@ class TestKlereoSensor:
 
     def test_creates_with_known_type(self, mock_coordinator):
         """Should use SENSOR_TYPES mapping for known probe types."""
-        probe = {"index": 0, "type": 5, "filteredValue": 28.5, "status": 0}
+        probe = _make_probe()
         sensor = KlereoSensor(mock_coordinator, "SYS1", probe)
         assert sensor._attr_name == "Water Temperature"
         assert sensor._attr_native_unit_of_measurement == "°C"
@@ -41,35 +53,35 @@ class TestKlereoSensor:
 
     def test_creates_with_unknown_type(self, mock_coordinator):
         """Should use fallback name for unknown probe types."""
-        probe = {"index": 99, "type": 999, "filteredValue": 50.0, "status": 0}
+        probe = _make_probe(index=99, type=999, filtered_value=50.0)
         sensor = KlereoSensor(mock_coordinator, "SYS1", probe)
         assert sensor._attr_name == "Sensor 99"
 
     def test_uses_filtered_value(self, mock_coordinator):
         """Should prefer filteredValue over directValue."""
-        probe = {"index": 0, "type": 5, "filteredValue": 28.5, "directValue": 28.4, "status": 0}
+        probe = _make_probe(filtered_value=28.5, direct_value=28.4)
         sensor = KlereoSensor(mock_coordinator, "SYS1", probe)
         assert sensor._attr_native_value == 28.5
 
     def test_falls_back_to_direct_value(self, mock_coordinator):
         """Should use directValue when filteredValue is None."""
-        probe = {"index": 0, "type": 5, "filteredValue": None, "directValue": 28.4, "status": 0}
+        probe = _make_probe(filtered_value=None, direct_value=28.4)
         sensor = KlereoSensor(mock_coordinator, "SYS1", probe)
         assert sensor._attr_native_value == 28.4
 
-    def test_find_my_data_uses_index(self, mock_coordinator):
-        """Should find probe data via _probe_index."""
-        probe = {"index": 0, "type": 5, "filteredValue": 28.5, "status": 0}
+    def test_find_my_probe_uses_index(self, mock_coordinator):
+        """Should find probe data via probe_index."""
+        probe = _make_probe()
         sensor = KlereoSensor(mock_coordinator, "SYS1", probe)
-        found = sensor._find_my_data()
+        found = sensor._find_my_probe()
         assert found is not None
-        assert found["filteredValue"] == 28.5
+        assert found.filtered_value == 28.5
 
-    def test_find_my_data_missing_system(self, mock_coordinator):
+    def test_find_my_probe_missing_system(self, mock_coordinator):
         """Should return None for missing system."""
-        probe = {"index": 0, "type": 5, "filteredValue": 28.5, "status": 0}
+        probe = _make_probe()
         sensor = KlereoSensor(mock_coordinator, "MISSING", probe)
-        assert sensor._find_my_data() is None
+        assert sensor._find_my_probe() is None
 
 
 class TestKlereoParamSensor:

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -4,27 +4,42 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.klereo.api import OUT_MODE_MAN, OUT_STATE_OFF, OUT_STATE_ON
+from custom_components.klereo.models import (
+    KlereoOutput,
+    KlereoPoolDetails,
+    KlereoSystemData,
+    KlereoSystemInfo,
+)
 from custom_components.klereo.switch import KlereoSwitch
+
+
+def _make_output(**kwargs) -> KlereoOutput:
+    """Create a KlereoOutput with defaults."""
+    defaults = {"index": 0, "status": 1, "mode": 0, "type": 0}
+    defaults.update(kwargs)
+    return KlereoOutput(**defaults)
 
 
 @pytest.fixture
 def mock_coordinator():
     """Create a mock coordinator."""
+    output = _make_output()
     coordinator = MagicMock()
     coordinator.api = AsyncMock()
     coordinator.api.set_output.return_value = {"response": "ok"}
     coordinator.async_request_refresh = AsyncMock()
     coordinator.async_set_output = AsyncMock()
     coordinator.data = {
-        "SYS1": {
-            "info": {"idSystem": "SYS1", "poolNickname": "My Pool"},
-            "details": {
-                "outs": [{"index": 0, "status": 1, "mode": 0, "type": 0}],
-                "_output_index": {
-                    0: {"index": 0, "status": 1, "mode": 0, "type": 0},
-                },
-            },
-        }
+        "SYS1": KlereoSystemData(
+            info=KlereoSystemInfo(id_system="SYS1", pool_nickname="My Pool"),
+            details=KlereoPoolDetails(
+                probes=[],
+                outs=[output],
+                regul_modes={},
+                probe_index={},
+                output_index={0: output},
+            ),
+        )
     }
     return coordinator
 
@@ -34,44 +49,44 @@ class TestKlereoSwitch:
 
     def test_creates_with_known_index(self, mock_coordinator):
         """Should use OUTPUT_NAMES for known indices."""
-        output = {"index": 0, "status": 1, "mode": 0, "type": 0}
+        output = _make_output()
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         assert switch._attr_name == "Lighting"
         assert switch._attr_unique_id == "SYS1_output_0"
 
     def test_is_on_when_status_equals_one(self, mock_coordinator):
         """Should be ON when status == OUT_STATE_ON (1)."""
-        output = {"index": 0, "status": 1, "mode": 0, "type": 0}
+        output = _make_output(status=1)
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         assert switch._attr_is_on is True
 
     def test_is_off_when_status_equals_zero(self, mock_coordinator):
         """Should be OFF when status == 0."""
-        output = {"index": 0, "status": 0, "mode": 0, "type": 0}
+        output = _make_output(status=0)
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         assert switch._attr_is_on is False
 
     def test_is_on_when_status_is_string_one(self, mock_coordinator):
         """Should be ON when status is string '1' (API may return strings)."""
-        output = {"index": 0, "status": "1", "mode": 0, "type": 0}
+        output = _make_output(status="1")
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         assert switch._attr_is_on is True
 
     def test_is_off_when_status_is_string_zero(self, mock_coordinator):
         """Should be OFF when status is string '0'."""
-        output = {"index": 0, "status": "0", "mode": 0, "type": 0}
+        output = _make_output(status="0")
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         assert switch._attr_is_on is False
 
     def test_is_off_when_status_is_none(self, mock_coordinator):
         """Should be OFF when status is None."""
-        output = {"index": 0, "status": None, "mode": 0, "type": 0}
+        output = _make_output(status=None)
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         assert switch._attr_is_on is False
 
     async def test_turn_on_calls_api(self, mock_coordinator):
         """turn_on should call async_set_output with correct args."""
-        output = {"index": 0, "status": 0, "mode": 0, "type": 0}
+        output = _make_output(status=0)
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         switch.async_write_ha_state = MagicMock()
         await switch.async_turn_on()
@@ -82,7 +97,7 @@ class TestKlereoSwitch:
 
     async def test_turn_off_calls_api(self, mock_coordinator):
         """turn_off should call async_set_output with correct args."""
-        output = {"index": 0, "status": 1, "mode": 0, "type": 0}
+        output = _make_output(status=1)
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         switch.async_write_ha_state = MagicMock()
         await switch.async_turn_off()
@@ -95,16 +110,16 @@ class TestKlereoSwitch:
         """turn_on should raise HomeAssistantError on coordinator failure."""
         from homeassistant.exceptions import HomeAssistantError
         mock_coordinator.async_set_output.side_effect = HomeAssistantError("Failed to set output 0: API down")
-        output = {"index": 0, "status": 0, "mode": 0, "type": 0}
+        output = _make_output(status=0)
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
         switch.async_write_ha_state = MagicMock()
         with pytest.raises(HomeAssistantError, match="Failed to set output"):
             await switch.async_turn_on()
 
-    def test_find_my_data_uses_index(self, mock_coordinator):
-        """Should find output data via _output_index."""
-        output = {"index": 0, "status": 1, "mode": 0, "type": 0}
+    def test_find_my_output_uses_index(self, mock_coordinator):
+        """Should find output data via output_index."""
+        output = _make_output()
         switch = KlereoSwitch(mock_coordinator, "SYS1", output)
-        found = switch._find_my_data()
+        found = switch._find_my_output()
         assert found is not None
-        assert found["status"] == 1
+        assert found.status == 1


### PR DESCRIPTION
## Summary
- Add `models.py` with typed dataclasses: `KlereoProbe`, `KlereoOutput`, `KlereoSystemInfo`, `KlereoPoolDetails`, `KlereoSystemData`
- Coordinator now parses API responses into typed objects via `from_dict()` class methods
- All entity files use typed attribute access (e.g. `probe.filtered_value`) instead of dict key lookups
- Diagnostics uses `dataclasses.asdict()` for serialization
- Also includes select entity + `OUTPUT_MODES` from #33 (same files touched)
- All 69 tests updated and passing

Closes #42.

## Test plan
- [ ] CI passes (lint, test, hacs)
- [ ] All entity types still work correctly in HA
- [ ] Diagnostics output still includes all expected data

🤖 Generated with [Claude Code](https://claude.com/claude-code)