### PR TITLE
feat: add binary_sensor platform for boolean probe types

### DIFF
--- a/custom_components/klereo/__init__.py
+++ b/custom_components/klereo/__init__.py
@@ -12,7 +12,7 @@ from .coordinator import KlereoCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SELECT, Platform.SENSOR, Platform.SWITCH]
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/klereo/binary_sensor.py
+++ b/custom_components/klereo/binary_sensor.py
@@ -1,0 +1,76 @@
+"""Binary sensor platform for Klereo."""
+import logging
+
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import BINARY_SENSOR_TYPES
+from .entity import KlereoEntity, setup_discovery
+from .models import KlereoPoolDetails, KlereoProbe
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _extract_binary_sensors(coordinator, system_id, details: KlereoPoolDetails):
+    """Extract binary sensors from system details."""
+    items = []
+    for probe in details.probes:
+        if probe.type not in BINARY_SENSOR_TYPES:
+            continue
+        uid = f"{system_id}_binary_sensor_{probe.index}"
+        items.append((uid, KlereoBinarySensor(coordinator, system_id, probe)))
+    return items
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Klereo binary sensors."""
+    setup_discovery(hass, entry, async_add_entities, _extract_binary_sensors)
+
+
+class KlereoBinarySensor(KlereoEntity, BinarySensorEntity):
+    """Representation of a Klereo binary probe sensor."""
+
+    def __init__(self, coordinator, system_id, probe: KlereoProbe):
+        """Initialize the binary sensor."""
+        super().__init__(coordinator, system_id)
+        self._index = probe.index
+        self._type = probe.type
+
+        sensor_def = BINARY_SENSOR_TYPES.get(self._type, {})
+
+        self._attr_unique_id = f"{system_id}_binary_sensor_{self._index}"
+        self._attr_name = sensor_def.get("name", f"Sensor {self._index}")
+        self._attr_device_class = sensor_def.get("device_class")
+
+        self._update_from_probe(probe)
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Handle updated data from the coordinator."""
+        probe = self._find_my_probe()
+        if probe:
+            self._attr_available = True
+            self._update_from_probe(probe)
+        else:
+            self._attr_available = False
+        super()._handle_coordinator_update()
+
+    def _update_from_probe(self, probe: KlereoProbe):
+        """Update state from probe data."""
+        value = probe.filtered_value
+        if value is None:
+            value = probe.direct_value
+        self._attr_is_on = bool(value) if value is not None else None
+
+    def _find_my_probe(self) -> KlereoProbe | None:
+        """Find this probe's data in the coordinator data."""
+        system = self.coordinator.data.get(self.system_id)
+        if system is None:
+            return None
+        return system.details.probe_index.get(self._index)

--- a/custom_components/klereo/const.py
+++ b/custom_components/klereo/const.py
@@ -13,6 +13,13 @@ SCAN_INTERVAL_MINUTES = 5
 
 # Probe type to sensor metadata mapping (from Jeedom _PROBE_TYPE_* constants)
 # state_class: "measurement" for continuous readings, None for positional/unknown values
+# Probe types that return binary 0/1 values and should be BinarySensorEntity
+BINARY_SENSOR_TYPES = {
+    10: {"name": "Generic", "device_class": None},
+}
+
+# Probe type to sensor metadata mapping (from Jeedom _PROBE_TYPE_* constants)
+# state_class: "measurement" for continuous readings, None for positional/unknown values
 SENSOR_TYPES = {
     0: {
         "name": "Technical Room Temperature", "unit": "°C",
@@ -24,7 +31,7 @@ SENSOR_TYPES = {
     4: {"name": "Redox", "unit": "mV", "device_class": "voltage", "state_class": "measurement"},
     5: {"name": "Water Temperature", "unit": "°C", "device_class": "temperature", "state_class": "measurement"},
     6: {"name": "Filter Pressure", "unit": "mbar", "device_class": "pressure", "state_class": "measurement"},
-    10: {"name": "Generic", "unit": "%", "device_class": None, "state_class": None},
+    # type 10 "Generic" moved to BINARY_SENSOR_TYPES
     11: {"name": "Flow", "unit": "m³/h", "device_class": None, "state_class": "measurement"},
     12: {"name": "Container Level", "unit": "%", "device_class": None, "state_class": "measurement"},
     13: {"name": "Cover Position", "unit": "%", "device_class": None, "state_class": None},

--- a/custom_components/klereo/sensor.py
+++ b/custom_components/klereo/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import PARAM_NAMES, PARAM_TYPES, SENSOR_TYPES
+from .const import BINARY_SENSOR_TYPES, PARAM_NAMES, PARAM_TYPES, SENSOR_TYPES
 from .entity import KlereoEntity, setup_discovery
 from .models import KlereoPoolDetails, KlereoProbe
 
@@ -23,6 +23,8 @@ def _extract_sensors(coordinator, system_id, details: KlereoPoolDetails):
     """Extract probe sensors and param sensors from system details."""
     items = []
     for probe in details.probes:
+        if probe.type in BINARY_SENSOR_TYPES:
+            continue
         uid = f"{system_id}_sensor_{probe.index}"
         items.append((uid, KlereoSensor(coordinator, system_id, probe)))
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,102 @@
+"""Tests for Klereo binary sensor entities."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.klereo.binary_sensor import KlereoBinarySensor
+from custom_components.klereo.models import (
+    KlereoPoolDetails,
+    KlereoProbe,
+    KlereoSystemData,
+    KlereoSystemInfo,
+)
+
+
+def _make_probe(**kwargs) -> KlereoProbe:
+    """Create a KlereoProbe with binary sensor defaults."""
+    defaults = {"index": 0, "type": 10, "filtered_value": 1, "direct_value": 1, "status": 0}
+    defaults.update(kwargs)
+    return KlereoProbe(**defaults)
+
+
+@pytest.fixture
+def mock_coordinator():
+    """Create a mock coordinator."""
+    probe = _make_probe()
+    coordinator = MagicMock()
+    coordinator.data = {
+        "SYS1": KlereoSystemData(
+            info=KlereoSystemInfo(id_system="SYS1", pool_nickname="My Pool"),
+            details=KlereoPoolDetails(
+                probes=[probe],
+                outs=[],
+                regul_modes={},
+                probe_index={0: probe},
+                output_index={},
+            ),
+        )
+    }
+    return coordinator
+
+
+class TestKlereoBinarySensor:
+    """Tests for KlereoBinarySensor."""
+
+    def test_creates_with_known_type(self, mock_coordinator):
+        """Should use BINARY_SENSOR_TYPES mapping for known probe types."""
+        probe = _make_probe()
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        assert sensor._attr_name == "Generic"
+        assert sensor._attr_unique_id == "SYS1_binary_sensor_0"
+        assert sensor._attr_device_class is None
+
+    def test_is_on_when_value_is_one(self, mock_coordinator):
+        """Should be ON when filtered_value is 1."""
+        probe = _make_probe(filtered_value=1)
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        assert sensor._attr_is_on is True
+
+    def test_is_off_when_value_is_zero(self, mock_coordinator):
+        """Should be OFF when filtered_value is 0."""
+        probe = _make_probe(filtered_value=0)
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        assert sensor._attr_is_on is False
+
+    def test_falls_back_to_direct_value(self, mock_coordinator):
+        """Should use direct_value when filtered_value is None."""
+        probe = _make_probe(filtered_value=None, direct_value=1)
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        assert sensor._attr_is_on is True
+
+    def test_is_none_when_no_value(self, mock_coordinator):
+        """Should be None when both values are None."""
+        probe = _make_probe(filtered_value=None, direct_value=None)
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        assert sensor._attr_is_on is None
+
+    def test_handle_coordinator_update_refreshes(self, mock_coordinator):
+        """Should update from coordinator data."""
+        probe = _make_probe(filtered_value=0)
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        sensor.async_write_ha_state = MagicMock()
+        # Update probe in coordinator
+        mock_coordinator.data["SYS1"].details.probe_index[0] = _make_probe(filtered_value=1)
+        sensor._handle_coordinator_update()
+        assert sensor._attr_is_on is True
+        assert sensor._attr_available is True
+
+    def test_handle_coordinator_update_missing_system(self, mock_coordinator):
+        """Should mark unavailable when system disappears."""
+        probe = _make_probe()
+        sensor = KlereoBinarySensor(mock_coordinator, "MISSING", probe)
+        sensor.async_write_ha_state = MagicMock()
+        sensor._handle_coordinator_update()
+        assert sensor._attr_available is False
+
+    def test_device_info(self, mock_coordinator):
+        """Should return device info from coordinator data."""
+        probe = _make_probe()
+        sensor = KlereoBinarySensor(mock_coordinator, "SYS1", probe)
+        info = sensor.device_info
+        assert ("klereo", "SYS1") in info["identifiers"]
+        assert info["name"] == "My Pool"


### PR DESCRIPTION
## Summary
- Add `KlereoBinarySensor` for probe types that return binary 0/1 values
- Probe type 10 (Generic) now creates `BinarySensorEntity` instead of `SensorEntity`
- `BINARY_SENSOR_TYPES` dict in const.py for easy extension
- Sensor discovery skips binary probe types to avoid duplicates
- 8 new tests in `test_binary_sensor.py` (77 total, all passing)

Closes #35.

## Test plan
- [ ] CI passes (lint, test, hacs)
- [ ] Type 10 probes appear as binary sensors in HA
- [ ] Non-binary probes still appear as regular sensors

🤖 Generated with [Claude Code](https://claude.com/claude-code)